### PR TITLE
Specify Cluster

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -6,6 +6,7 @@ Use this plugin for deploying a docker container application to AWS EC2 Containe
 * `secret_key` - AWS secret access key
 * `region` - AWS availability zone
 * `service` - Name of the service in the cluster, **MUST** be created already in ECS
+* `cluster` - Name of the cluster. Optional. Default cluster is used if not specified
 * `family` - Family name of the task definition to create or update with a new revision
 * `image_name`, Container image to use, do not include the tag here
 * `image_tag` - Tag of the image to use, defaults to latest

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ import (
 )
 
 var (
-	build     string
 	buildDate string
 )
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 )
 
 var (
+	build     string
 	buildDate string
 )
 
@@ -76,6 +77,12 @@ func main() {
 
 		os.Exit(1)
 		return
+	}
+
+	if len(vargs.Cluster) == 0 {
+		fmt.Println("Cluster: default")
+	} else {
+		fmt.Printf("Cluster: %s\n", vargs.Cluster)
 	}
 
 	if vargs.Memory == 0 {
@@ -168,6 +175,7 @@ func main() {
 
 	val := *(resp.TaskDefinition.TaskDefinitionArn)
 	sparams := &ecs.UpdateServiceInput{
+		Cluster:        aws.String(vargs.Cluster),
 		Service:        aws.String(vargs.Service),
 		TaskDefinition: aws.String(val),
 	}

--- a/types.go
+++ b/types.go
@@ -12,6 +12,7 @@ type Params struct {
 	Image        string            `json:"image_name"`
 	Tag          string            `json:"image_tag"`
 	Service      string            `json:"service"`
+	Cluster      string            `json:"cluster"`
 	Memory       int64             `json:"memory"`
 	Environment  drone.StringSlice `json:"environment_variables"`
 	PortMappings drone.StringSlice `json:"port_mappings"`


### PR DESCRIPTION
Small change to allow the ecs cluster name to be specified in drone.yml. Plugin currently always uses the  default cluster.
