### PR TITLE
Add network mode option

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "network-mode",
 			Usage:  "The Docker networking mode to use for the containers in the task. Defaults to bridge if unspecified",
-			EnvVar: "PLUGIN_NETWORK_MODE",
+			EnvVar: "PLUGIN_TASK_NETWORK_MODE",
 		},
 		cli.StringFlag{
 			Name:   "deployment-configuration",
@@ -159,6 +159,7 @@ func run(c *cli.Context) error {
 		CPU:                     c.Int64("cpu"),
 		Memory:                  c.Int64("memory"),
 		MemoryReservation:       c.Int64("memory-reservation"),
+		NetworkMode:             c.String("network-mode"),
 		DeploymentConfiguration: c.String("deployment-configuration"),
 		DesiredCount:            c.Int64("desired-count"),
 		YamlVerified:            c.BoolT("yaml-verified"),

--- a/main.go
+++ b/main.go
@@ -113,6 +113,11 @@ func main() {
 			EnvVar: "PLUGIN_MEMORY_RESERVATION",
 		},
 		cli.StringFlag{
+			Name:   "network-mode",
+			Usage:  "The Docker networking mode to use for the containers in the task. Defaults to bridge if unspecified",
+			EnvVar: "PLUGIN_NETWORK_MODE",
+		},
+		cli.StringFlag{
 			Name:   "deployment-configuration",
 			Usage:  "Deployment parameters that control how many tasks run during the deployment and the ordering of stopping and starting tasks",
 			EnvVar: "PLUGIN_DEPLOYMENT_CONFIGURATION",

--- a/plugin.go
+++ b/plugin.go
@@ -34,6 +34,7 @@ type Plugin struct {
 	CPU                     int64
 	Memory                  int64
 	MemoryReservation       int64
+	NetworkMode             string
 	YamlVerified            bool
 }
 
@@ -128,17 +129,17 @@ func (p *Plugin) Exec() error {
 	// Secret Environment variables
 	for _, envVar := range p.SecretEnvironment {
 		parts := strings.SplitN(envVar, "=", 2)
-		pair := ecs.KeyValuePair{};
-		if (len(parts) == 2) {
+		pair := ecs.KeyValuePair{}
+		if len(parts) == 2 {
 			// set to custom named variable
-			pair.SetName(aws.StringValue(aws.String(strings.Trim(parts[0], " "))));
-			pair.SetValue(aws.StringValue(aws.String(os.Getenv(strings.Trim(parts[1], " ")))));
-		} else if (len(parts) == 1) {
+			pair.SetName(aws.StringValue(aws.String(strings.Trim(parts[0], " "))))
+			pair.SetValue(aws.StringValue(aws.String(os.Getenv(strings.Trim(parts[1], " ")))))
+		} else if len(parts) == 1 {
 			// default to named var
-			pair.SetName(aws.StringValue(aws.String(parts[0])));
-			pair.SetValue(aws.StringValue(aws.String(os.Getenv(parts[0]))));
+			pair.SetName(aws.StringValue(aws.String(parts[0])))
+			pair.SetValue(aws.StringValue(aws.String(os.Getenv(parts[0]))))
 		} else {
-			fmt.Println("invalid syntax in secret enironment var", envVar);
+			fmt.Println("invalid syntax in secret enironment var", envVar)
 		}
 		definition.Environment = append(definition.Environment, &pair)
 	}
@@ -164,6 +165,10 @@ func (p *Plugin) Exec() error {
 		}
 	}
 
+	if len(p.NetworkMode) == 0 {
+		p.NetworkMode = "bridge"
+	}
+
 	params := &ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: []*ecs.ContainerDefinition{
 			&definition,
@@ -171,6 +176,7 @@ func (p *Plugin) Exec() error {
 		Family:      aws.String(p.Family),
 		Volumes:     []*ecs.Volume{},
 		TaskRoleArn: aws.String(p.TaskRoleArn),
+		NetworkMode: aws.String(p.NetworkMode),
 	}
 	resp, err := svc.RegisterTaskDefinition(params)
 


### PR DESCRIPTION
Setting network mode is required for support with Fargate. When unset this plugin should behave as before.

I tried to check https://gitter.im/drone/drone as the PR template recommends, but the URL 404s for me.

`go fmt` also had some cleanup to do, so I've committed that here. Happy to move to a separate PR if desired.
