### PR TITLE
Allow for desired count of 0

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -185,7 +185,7 @@ func (p *Plugin) Exec() error {
 		TaskDefinition: aws.String(val),
 	}
 
-	if p.DesiredCount != 0 {
+	if p.DesiredCount >= 0 {
 		sparams.DesiredCount = aws.Int64(p.DesiredCount)
 	}
 


### PR DESCRIPTION
AWS allows you to scale a service down to 0, this is useful, for example, when you want to use a service as a canary.

Fixes #24.