### PR TITLE
Attempting to support other Task variables in order to support FARGATE launch type

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -23,6 +23,10 @@ Use this plugin for deploying a docker container application to AWS EC2 Containe
 * `log_options` - The configuration options to send to the log driver
 * `labels` - A key/value map of labels to add to the container
 * `secret_environment_variables` - List of Environment Variables to be injected into the container from drone secrets. You can use the name of the secret itself or set a custom name to be used within the container. Syntax is `NAME` (must match the name of one of your secrets) or `CUSTOM_NAME=NAME`
+* `task_cpu` - The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu
+* `task_memory` - The amount of memory (in MiB) used by the task.It can be expressed as an integer using MiB, for example 1024, or as a string using GB. Required if using Fargate launch type
+* `task_execution_role_arn` - The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
+* `compatibilities` - List of launch types supported by the task, defaults to EC2 if not specified
 
 
 ## Example

--- a/main.go
+++ b/main.go
@@ -132,6 +132,26 @@ func main() {
 			Usage:  "Ensure the yaml was signed",
 			EnvVar: "DRONE_YAML_VERIFIED",
 		},
+		cli.StringFlag{
+			Name:   "task-cpu",
+			Usage:  "The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu",
+			EnvVar: "PLUGIN_TASK_CPU",
+		},
+		cli.StringFlag{
+			Name:   "task-memory",
+			Usage:  "The amount of memory (in MiB) used by the task.It can be expressed as an integer using MiB, for example 1024, or as a string using GB. Required if using Fargate launch type",
+			EnvVar: "PLUGIN_TASK_MEMORY",
+		},
+		cli.StringFlag{
+			Name:   "task-execution-role-arn",
+			Usage:  "The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.",
+			EnvVar: "PLUGIN_TASK_EXECUTION_ROLE_ARN",
+		},
+		cli.StringFlag{
+			Name:   "compatibilities",
+			Usage:  "List of launch types supported by the task",
+			EnvVar: "PLUGIN_COMPATIBILITIES",
+		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
@@ -163,6 +183,10 @@ func run(c *cli.Context) error {
 		DeploymentConfiguration: c.String("deployment-configuration"),
 		DesiredCount:            c.Int64("desired-count"),
 		YamlVerified:            c.BoolT("yaml-verified"),
+		TaskCPU:                 c.String("task-cpu"),
+		TaskMemory:              c.String("task-memory"),
+		TaskExecutionRoleArn:    c.String("task-execution-role-arn"),
+		Compatibilities:         c.String("compatibilities"),
 	}
 	return plugin.Exec()
 }

--- a/plugin.go
+++ b/plugin.go
@@ -36,6 +36,10 @@ type Plugin struct {
 	MemoryReservation       int64
 	NetworkMode             string
 	YamlVerified            bool
+	TaskCPU                 string
+	TaskMemory              string
+	TaskExecutionRoleArn    string
+	Compatibilities         string
 }
 
 func (p *Plugin) Exec() error {
@@ -173,10 +177,29 @@ func (p *Plugin) Exec() error {
 		ContainerDefinitions: []*ecs.ContainerDefinition{
 			&definition,
 		},
-		Family:      aws.String(p.Family),
-		Volumes:     []*ecs.Volume{},
-		TaskRoleArn: aws.String(p.TaskRoleArn),
-		NetworkMode: aws.String(p.NetworkMode),
+		Family:                  aws.String(p.Family),
+		Volumes:                 []*ecs.Volume{},
+		TaskRoleArn:             aws.String(p.TaskRoleArn),
+		NetworkMode:             aws.String(p.NetworkMode),
+	}
+
+	cleanedCompatibilities := strings.Trim(p.Compatibilities, " ")
+	compatibilitySlice := strings.Split(cleanedCompatibilities, " ")
+
+	if cleanedCompatibilities != "" && len(compatibilitySlice) != 0 {
+		params.RequiresCompatibilities = aws.StringSlice(compatibilitySlice)
+	}
+
+	if len(p.TaskCPU) != 0 {
+		params.Cpu = aws.String(p.TaskCPU)
+	}
+
+	if len(p.TaskMemory) != 0 {
+		params.Memory = aws.String(p.TaskMemory)
+	}
+
+	if len(p.TaskExecutionRoleArn) != 0 {
+		params.ExecutionRoleArn = aws.String(p.TaskExecutionRoleArn)
 	}
 	resp, err := svc.RegisterTaskDefinition(params)
 


### PR DESCRIPTION
In order to support the fargate launch type, the cpu, memory, execution_role, task_execution_role_arn needs to be specified in `RegisterTaskDefinitionInput`. I just went ahead and exposed these to drone.  i believe it should address issue #27 

Sample drone config
```
  deploy:
    image: mlibrodo/drone-ecs:latest
    when:
      branch: master
    access_key: XXXXXXXX
    secret_key: XXXXXXXX
    region: us-east-2
    family: task-definition-family
    docker_image: namespace/repo
    container_name: container1
    tag: latest
    cluster: some-fargate-cluster
    service: some-service
    task_network_mode: awsvpc
    port_mappings:
      - 9000 9000
    deployment_configuration: 50 200
    log_driver: awslogs
    log_options:
      - awslogs-group=/ecs/someservice
      - awslogs-region=us-east-2
      - awslogs-stream-prefix=ecs
    environment_variables:
      - SERVICE_CONFIG=XXXXX
    cpu: 4096
    memoryReservation: 128
    task_cpu: 4096
    task_memory: 8192
    task_execution_role_arn: arn:aws:iam::XXXXX:role/ecsTaskExecutionRole
    compatibilities: FARGATE EC2
    desired_count: 2
```