### PR TITLE
Update network-mode env var to be consistent with other CLI flags.

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,9 +117,9 @@ func main() {
 			EnvVar: "PLUGIN_MEMORY_RESERVATION",
 		},
 		cli.StringFlag{
-			Name:   "network-mode",
+			Name:   "task-network-mode",
 			Usage:  "The Docker networking mode to use for the containers in the task. Defaults to bridge if unspecified",
-			EnvVar: "PLUGIN_NETWORK_MODE",
+			EnvVar: "PLUGIN_TASK_NETWORK_MODE",
 		},
 		cli.StringFlag{
 			Name:   "deployment-configuration",

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "network-mode",
 			Usage:  "The Docker networking mode to use for the containers in the task. Defaults to bridge if unspecified",
-			EnvVar: "PLUGIN_TASK_NETWORK_MODE",
+			EnvVar: "PLUGIN_NETWORK_MODE",
 		},
 		cli.StringFlag{
 			Name:   "deployment-configuration",


### PR DESCRIPTION
The network-mode CLI flag had an env var set to
PLUGIN_TASK_NETWORK_MODE which broken convention with all other
CLI flags and made it confusing to switch between using drone.yaml
config files and running the plugin differently.

This change updates the env var to be consistent so the user
experience is smoother.