### PR TITLE
Expose ulimits as a configurable setting

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -31,6 +31,7 @@ Use this plugin for deploying a docker container application to AWS EC2 Containe
 * `service_network_assign_public_ip` - Whether the task's elastic network interface receives a public IP address. The default value is DISABLED.
 * `service_network_subnets` - The security groups associated with the task or service. If you do not specify a security group, the default security group for the VPC is used. There is a limit of 5 security groups that can be specified per AwsVpcConfiguration.
 * `service_network_security_groups` - The subnets associated with the task or service. There is a limit of 16 subnets that can be specified per AwsVpcConfiguration.
+* `ulimits` - The Ulimit property specifies the ulimit settings to pass to the container. This is an array of strings in the format: `name softLimit hardLimit` where name is one of: core, cpu, data, fsize, locks, memlock, msgqueue, nice, nofile, nproc, rss, rtprio, rttime, sigpending, stack and soft/hard limits are integers.
 
 ## Example
 
@@ -63,5 +64,7 @@ steps:
       cpu: 1024
       desired_count: 1
       deployment_configuration: 50 200
+      ulimits:
+        - nofile 2048 4096
       secrets: [AWS_SECRET_KEY, AWS_ACCESS_KEY]
 ```

--- a/main.go
+++ b/main.go
@@ -201,6 +201,11 @@ func main() {
 			Usage:  "The subnets to associate with the service",
 			EnvVar: "PLUGIN_SERVICE_NETWORK_SUBNETS",
 		},
+		cli.StringSliceFlag{
+			Name:   "ulimits",
+			Usage:  "ECS ulimits",
+			EnvVar: "PLUGIN_ULIMITS",
+		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
@@ -244,6 +249,7 @@ func run(c *cli.Context) error {
 		ServiceNetworkAssignPublicIp: c.String("service-network-assign-public-ip"),
 		ServiceNetworkSecurityGroups: c.StringSlice("service-network-security-groups"),
 		ServiceNetworkSubnets:        c.StringSlice("service-network-subnets"),
+		ULimits                       c.StringSlice("ulimits"),
 	}
 	return plugin.Exec()
 }

--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func run(c *cli.Context) error {
 		ServiceNetworkAssignPublicIp: c.String("service-network-assign-public-ip"),
 		ServiceNetworkSecurityGroups: c.StringSlice("service-network-security-groups"),
 		ServiceNetworkSubnets:        c.StringSlice("service-network-subnets"),
-		ULimits                       c.StringSlice("ulimits"),
+		ULimits:                      c.StringSlice("ulimits"),
 	}
 	return plugin.Exec()
 }

--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func run(c *cli.Context) error {
 		ServiceNetworkAssignPublicIp: c.String("service-network-assign-public-ip"),
 		ServiceNetworkSecurityGroups: c.StringSlice("service-network-security-groups"),
 		ServiceNetworkSubnets:        c.StringSlice("service-network-subnets"),
-		ULimits:                      c.StringSlice("ulimits"),
+		Ulimits:                      c.StringSlice("ulimits"),
 	}
 	return plugin.Exec()
 }

--- a/plugin.go
+++ b/plugin.go
@@ -61,6 +61,8 @@ type Plugin struct {
 }
 
 const (
+	softLimitBaseParseErr             = "error parsing ulimits softLimit: "
+	hardLimitBaseParseErr             = "error parsing ulimits hardLimit: "
 	hostPortBaseParseErr              = "error parsing port_mappings hostPort: "
 	containerBaseParseErr             = "error parsing port_mappings containerPort: "
 	minimumHealthyPercentBaseParseErr = "error parsing deployment_configuration minimumHealthyPercent: "

--- a/plugin.go
+++ b/plugin.go
@@ -196,7 +196,7 @@ func (p *Plugin) Exec() error {
 		}
 
 		pair := ecs.Ulimit{
-			Name: awsString(name),
+			Name: aws.String(name),
 			HardLimit: aws.Int64(hardLimit),
 			SoftLimit: aws.Int64(softLimit),
 		}


### PR DESCRIPTION
I'm not really familiar with Go, so this is mostly a stab in the dark, but based on other existing parts of the plugin code I _think_ this is accurate. It would be good to get ulimits config exposed, I have code in production that depends on a higher than default nofile ulimit.
