### PR TITLE
Adding a local variable to avoid wrong value due pointer address

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -253,7 +253,9 @@ func (p *Plugin) Exec() error {
 
 	// EntryPoint
 	for _, v := range p.EntryPoint {
-		definition.EntryPoint = append(definition.EntryPoint, &v)
+		var command string
+		command = v
+		definition.EntryPoint = append(definition.EntryPoint, &command)
 	}
 
 	// LogOptions


### PR DESCRIPTION
Due a pointer wrong reference, when I try to pass more than one command, this happens:

![image](https://user-images.githubusercontent.com/22237876/72828065-acad8e80-3c5a-11ea-95e7-ad581b12cf47.png)

Fixing with that article in mind: https://medium.com/codezillas/uh-ohs-in-go-slice-of-pointers-c0a30669feee
