### PR TITLE
Add support for changing user role ARN

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -4,6 +4,7 @@ Use this plugin for deploying a docker container application to AWS EC2 Containe
 
 * `access_key` - AWS access key ID, MUST be an IAM user with the AmazonEC2ContainerServiceFullAccess policy attached
 * `secret_key` - AWS secret access key
+* `user_role_arn` - AWS user role. Optional. Switch to different role after initial authentication
 * `region` - AWS availability zone
 * `service` - Name of the service in the cluster, **MUST** be created already in ECS
 * `container_name` - Name of the container, defaults to ${family}-container

--- a/main.go
+++ b/main.go
@@ -31,6 +31,11 @@ func main() {
 			EnvVar: "PLUGIN_SECRET_KEY,ECS_SECRET_KEY,AWS_SECRET_KEY",
 		},
 		cli.StringFlag{
+			Name:   "user-role-arn",
+			Usage:  "AWS user role",
+			EnvVar: "PLUGIN_USER_ROLE_ARN,ECS_USER_ROLE_ARN,AWS_USER_ROLE_ARN",
+		},
+		cli.StringFlag{
 			Name:   "region",
 			Usage:  "aws region",
 			EnvVar: "PLUGIN_REGION",
@@ -231,6 +236,7 @@ func run(c *cli.Context) error {
 	plugin := Plugin{
 		Key:                          c.String("access-key"),
 		Secret:                       c.String("secret-key"),
+		UserRoleArn:                  c.String("user-role-arn"),
 		Region:                       c.String("region"),
 		Family:                       c.String("family"),
 		TaskRoleArn:                  c.String("task-role-arn"),

--- a/plugin.go
+++ b/plugin.go
@@ -17,7 +17,7 @@ import (
 type Plugin struct {
 	Key                     string
 	Secret                  string
-	UserRoleArn				string
+	UserRoleArn             string
 	Region                  string
 	Family                  string
 	TaskRoleArn             string

--- a/plugin.go
+++ b/plugin.go
@@ -89,12 +89,9 @@ func (p *Plugin) Exec() error {
 
 	// If user role ARN is set then assume role here
 	if len(p.UserRoleArn) > 0 {
-		var arnCredentials *credentials.Credentials
-
 		awsConfigArn := aws.Config{Region: aws.String(p.Region)}
-		arnCredentials = stscreds.NewCredentials(sess, p.UserRoleArn, func(p *stscreds.AssumeRoleProvider) {})
+		arnCredentials := stscreds.NewCredentials(sess, p.UserRoleArn)
 		awsConfigArn.Credentials = arnCredentials
-
 		svc = ecs.New(sess, &awsConfigArn)
 	} else {
 		svc = ecs.New(sess)
@@ -338,7 +335,6 @@ func (p *Plugin) Exec() error {
 
 	resp, err := svc.RegisterTaskDefinition(params)
 	if err != nil {
-		fmt.Println("Error when registering task definition:", err.Error())
 		return err
 	}
 
@@ -376,7 +372,6 @@ func (p *Plugin) Exec() error {
 
 	sresp, serr := svc.UpdateService(sparams)
 	if serr != nil {
-		fmt.Println("Error when updating service:", serr.Error())
 		return serr
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
@@ -16,6 +17,7 @@ import (
 type Plugin struct {
 	Key                     string
 	Secret                  string
+	UserRoleArn				string
 	Region                  string
 	Family                  string
 	TaskRoleArn             string
@@ -81,7 +83,22 @@ func (p *Plugin) Exec() error {
 		awsConfig.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
 	}
 	awsConfig.Region = aws.String(p.Region)
-	svc := ecs.New(session.New(&awsConfig))
+
+	var svc *ecs.ECS
+	sess := session.Must(session.NewSession(&awsConfig))
+
+	// If user role ARN is set then assume role here
+	if len(p.UserRoleArn) > 0 {
+		var arnCredentials *credentials.Credentials
+
+		awsConfigArn := aws.Config{Region: aws.String(p.Region)}
+		arnCredentials = stscreds.NewCredentials(sess, p.UserRoleArn, func(p *stscreds.AssumeRoleProvider) {})
+		awsConfigArn.Credentials = arnCredentials
+
+		svc = ecs.New(sess, &awsConfigArn)
+	} else {
+		svc = ecs.New(sess)
+	}
 
 	Image := p.DockerImage + ":" + p.Tag
 	if len(p.ContainerName) == 0 {
@@ -184,7 +201,7 @@ func (p *Plugin) Exec() error {
 		pair := ecs.PortMapping{
 			ContainerPort: aws.Int64(containerPort),
 			HostPort:      aws.Int64(hostPort),
-			Protocol:      aws.String("TransportProtocol"),
+			Protocol:      aws.String("tcp"),
 		}
 
 		definition.PortMappings = append(definition.PortMappings, &pair)
@@ -321,6 +338,7 @@ func (p *Plugin) Exec() error {
 
 	resp, err := svc.RegisterTaskDefinition(params)
 	if err != nil {
+		fmt.Println("Error when registering task definition:", err.Error())
 		return err
 	}
 
@@ -358,6 +376,7 @@ func (p *Plugin) Exec() error {
 
 	sresp, serr := svc.UpdateService(sparams)
 	if serr != nil {
+		fmt.Println("Error when updating service:", serr.Error())
 		return serr
 	}
 


### PR DESCRIPTION
Hi,

My first pull request so please bare with me if this is not done entirely right. 😄 

These changes allow authentication with a common AWS user account and then switch to required role ARN.

Drone yml settings example:
```
user_role_arn: arn:aws:iam::012345678901:role/APP_TEST_QA_SERVICE
access_key:
    from_secret: aws_access_key_id
secret_key:
    from_secret: aws_secret_access_key
```

Issue: https://github.com/josmo/drone-ecs/issues/52