### PR TITLE
Support for AWS secrets manager and parameter store

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -25,6 +25,7 @@ Use this plugin for deploying a docker container application to AWS EC2 Containe
 * `labels` - A key/value map of labels to add to the container
 * `entry_point` - A list of strings to build the container entry point configuration
 * `secret_environment_variables` - List of Environment Variables to be injected into the container from drone secrets. You can use the name of the secret itself or set a custom name to be used within the container. Syntax is `NAME` (must match the name of one of your secrets) or `CUSTOM_NAME=NAME`
+* `secrets_manager_variables` - List of Environment Variables to be injected into the container from AWS secrets manager, format is `NAME=VALUE`. `VALUE` must match the resource name in AWS secrets manager. I.e. `arn:aws:secretsmanager:region:aws_account_id:secret:password-xxxx`
 * `task_cpu` - The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu
 * `task_memory` - The amount of memory (in MiB) used by the task.It can be expressed as an integer using MiB, for example 1024, or as a string using GB. Required if using Fargate launch type
 * `task_execution_role_arn` - The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.

--- a/main.go
+++ b/main.go
@@ -110,6 +110,11 @@ func main() {
 			Usage:  "Secret ECS environment-variables",
 			EnvVar: "PLUGIN_SECRET_ENVIRONMENT_VARIABLES",
 		},
+		cli.StringSliceFlag{
+			Name:   "secrets-manager-variables",
+			Usage:  "Environment-variables from AWS Secrets manager",
+			EnvVar: "PLUGIN_SECRETS_MANAGER_VARIABLES",
+		},
 		cli.Int64Flag{
 			Name:   "cpu",
 			Usage:  "The number of cpu units to reserve for the container",
@@ -250,6 +255,7 @@ func run(c *cli.Context) error {
 		PortMappings:                 c.StringSlice("port-mappings"),
 		Environment:                  c.StringSlice("environment-variables"),
 		SecretEnvironment:            c.StringSlice("secret-environment-variables"),
+		SecretsManagerEnvironment:    c.StringSlice("secrets-manager-variables"),
 		EntryPoint:                   c.StringSlice("entry-point"),
 		Labels:                       c.StringSlice("labels"),
 		CPU:                          c.Int64("cpu"),

--- a/plugin.go
+++ b/plugin.go
@@ -15,43 +15,44 @@ import (
 )
 
 type Plugin struct {
-	Key                     string
-	Secret                  string
-	UserRoleArn             string
-	Region                  string
-	Family                  string
-	TaskRoleArn             string
-	Service                 string
-	ContainerName           string
-	DockerImage             string
-	Tag                     string
-	Cluster                 string
-	LogDriver               string
-	LogOptions              []string
-	DeploymentConfiguration string
-	PortMappings            []string
-	Environment             []string
-	SecretEnvironment       []string
-	Labels                  []string
-	EntryPoint              []string
-	DesiredCount            int64
-	CPU                     int64
-	Memory                  int64
-	MemoryReservation       int64
-	NetworkMode             string
-	YamlVerified            bool
-	TaskCPU                 string
-	TaskMemory              string
-	TaskExecutionRoleArn    string
-	Compatibilities         string
-	HealthCheckCommand      []string
-	HealthCheckInterval     int64
-	HealthCheckRetries      int64
-	HealthCheckStartPeriod  int64
-	HealthCheckTimeout      int64
-	Ulimits                 []string
-	MountPoints             []string
-	Volumes                 []string
+	Key                       string
+	Secret                    string
+	UserRoleArn               string
+	Region                    string
+	Family                    string
+	TaskRoleArn               string
+	Service                   string
+	ContainerName             string
+	DockerImage               string
+	Tag                       string
+	Cluster                   string
+	LogDriver                 string
+	LogOptions                []string
+	DeploymentConfiguration   string
+	PortMappings              []string
+	Environment               []string
+	SecretEnvironment         []string
+	SecretsManagerEnvironment []string
+	Labels                    []string
+	EntryPoint                []string
+	DesiredCount              int64
+	CPU                       int64
+	Memory                    int64
+	MemoryReservation         int64
+	NetworkMode               string
+	YamlVerified              bool
+	TaskCPU                   string
+	TaskMemory                string
+	TaskExecutionRoleArn      string
+	Compatibilities           string
+	HealthCheckCommand        []string
+	HealthCheckInterval       int64
+	HealthCheckRetries        int64
+	HealthCheckStartPeriod    int64
+	HealthCheckTimeout        int64
+	Ulimits                   []string
+	MountPoints               []string
+	Volumes                   []string
 
 	// ServiceNetworkAssignPublicIP - Whether the task's elastic network interface receives a public IP address. The default value is DISABLED.
 	ServiceNetworkAssignPublicIp string
@@ -111,6 +112,7 @@ func (p *Plugin) Exec() error {
 		DockerSecurityOptions: []*string{},
 		EntryPoint:            []*string{},
 		Environment:           []*ecs.KeyValuePair{},
+		Secrets:               []*ecs.Secret{},
 		Essential:             aws.Bool(true),
 		ExtraHosts:            []*ecs.HostEntry{},
 
@@ -230,6 +232,16 @@ func (p *Plugin) Exec() error {
 			fmt.Println("invalid syntax in secret enironment var", envVar)
 		}
 		definition.Environment = append(definition.Environment, &pair)
+	}
+
+	// Environment variables from AWS Secrets manager
+	for _, envVar := range p.SecretsManagerEnvironment {
+		parts := strings.SplitN(envVar, "=", 2)
+		pair := ecs.Secret{
+			Name:  aws.String(strings.Trim(parts[0], " ")),
+			ValueFrom: aws.String(strings.Trim(parts[1], " ")),
+		}
+		definition.Secrets = append(definition.Secrets, &pair)
 	}
 
 	// Ulimits


### PR DESCRIPTION
Hi,

When using Drone secrets manager the secret variables are visible in plain text in the task definition. I had a requirement from my cybersecurity team to use AWS secrets manager or Parameter store (in systems manager) for all secrets. This pull request adds support for this. 

Example:
```
  - name: deploy
    image: tallinger/drone-ecs:latest
    settings:
      ...
      secrets_manager_variables:
        - APP_KEY=arn:aws:ssm:eu-central-1:1234567890:parameter/secrets/app_key
```